### PR TITLE
dts/amr/st: stm32h7: qspi added

### DIFF
--- a/boards/arm/smartguardcom/smartguardcom.dts
+++ b/boards/arm/smartguardcom/smartguardcom.dts
@@ -20,6 +20,7 @@
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;
 		zephyr,code-partition = &slot0_partition;
+        zephyr,flash-controller = &w25q128jvsim;
 	};
 
 	/*
@@ -186,11 +187,11 @@
 			read-only;
 		};
 
-		/* storage: 128KB for settings */
-		storage_partition: partition@20000 {
-			label = "storage";
-			reg = <0x00020000 0x00020000>;
-		};
+//		/* storage: 128KB for settings */
+//		storage_partition: partition@20000 {
+//			label = "storage";
+//			reg = <0x00020000 0x00020000>;
+//		};
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@40000 {
@@ -211,4 +212,39 @@
 		};
 
 	};
+};
+
+&quadspi {
+    pinctrl-0 = <&quadspi_clk_pb2
+                 &quadspi_bk1_ncs_pb10
+                 &quadspi_bk1_io0_pd11
+                 &quadspi_bk1_io1_pd12
+                 &quadspi_bk1_io2_pe2
+                 &quadspi_bk1_io3_pd13>;
+//    dmas = <&dma1 5 5 0x0000 0x03>;
+//    dma-names = "tx_rx";
+
+    status = "okay";
+
+    w25q128jvsim: qspi-nor-flash@0 {
+        compatible = "st,stm32-qspi-nor";
+        label = "W25Q128JVSIM";
+        reg = <0>;
+        qspi-max-frequency = <100000000>;
+        /* 128 Megabits = 16 Megabytes */
+        size = <0x8000000>;
+
+        status = "okay";
+
+        partitions {
+            compatible = "fixed-partitions";
+            #address-cells = <1>;
+            #size-cells = <1>;
+
+            fs_storage_partition: partition@0 {
+                label = "storage";
+                reg = <0x00000000 DT_SIZE_M(16)>;
+            };
+        };
+    };
 };

--- a/drivers/flash/Kconfig.stm32_qspi
+++ b/drivers/flash/Kconfig.stm32_qspi
@@ -12,6 +12,7 @@ config FLASH_STM32_QSPI
 	depends on SOC_FAMILY_STM32
 	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_QSPI_NOR))
 	select USE_STM32_HAL_QSPI
+	select USE_STM32_HAL_MDMA
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_JESD216
 	select FLASH_PAGE_LAYOUT

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -298,6 +298,17 @@
 			label = "I2C_4";
 		};
 
+		quadspi: quadspi@52005000 {
+            compatible = "st,stm32-qspi";
+            #address-cells = <1>;
+            #size-cells = <0>;
+            reg = <0x52005000 0x400>;
+            interrupts = <92 0>;
+            clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00004000>;
+            status = "disabled";
+            label = "QUADSPI";
+        };
+
 		spi1: spi@40013000 {
 			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;


### PR DESCRIPTION
dts/amr/st: stm32h7: qspi added
driver/flash: Kconfig.stm32_qspi: MDMA selected as quick fix to solve compiler errors
boards: qspi node added

Signed-off-by: raphael <loeffel@rte-ag.ch>